### PR TITLE
Add missing whitespace

### DIFF
--- a/FAQ.Rmd
+++ b/FAQ.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions"
 ---
-###Who May Use These Data?
+### Who May Use These Data?
 The content here is distributed under a [Creative Commons Attribution-ShareAlike License](https://creativecommons.org/licenses/). This license lets others remix, adapt, and build upon this work even for commercial purposes, as long as credit is provided and license their new creations under the identical terms.
 
 ### What Does the Early Vote Tell Us?


### PR DESCRIPTION
Fixing this headline on the FAQ

<img width="976" alt="Screen Shot 2020-09-24 at 3 11 07 PM" src="https://user-images.githubusercontent.com/4304548/94195213-57282200-fe78-11ea-8149-907b49cac71a.png">

I believe the change on line 53 was add automatically be the editor on github.com