### PR TITLE
GA Typo Fixes

### DIFF
--- a/GA.Rmd
+++ b/GA.Rmd
@@ -467,7 +467,7 @@ kable(GA_voted_race, format.args = list(big.mark = ",",
   kable_styling(bootstrap_options = "striped", full_width = F, position = "left")
 ```
 
-#### Total Voted by by Age
+#### Total Voted by Age
 
 ``` {r echo = FALSE}
 kable(GA_voted_age, format.args = list(big.mark = ",", 
@@ -475,7 +475,7 @@ kable(GA_voted_age, format.args = list(big.mark = ",",
   kable_styling(bootstrap_options = "striped", full_width = F, position = "left")
 ```
 
-#### Total Voted by by Gender
+#### Total Voted by Gender
 
 ``` {r echo = FALSE}
 kable(GA_voted_gender, format.args = list(big.mark = ",", 

--- a/docs/GA.html
+++ b/docs/GA.html
@@ -457,7 +457,7 @@ TOTAL
 </table>
 </div>
 <div id="total-voted-by-by-age" class="section level4">
-<h4>Total Voted by by Age</h4>
+<h4>Total Voted by Age</h4>
 <table class="table table-striped" style="width: auto !important; ">
 <thead>
 <tr>
@@ -565,7 +565,7 @@ TOTAL
 </table>
 </div>
 <div id="total-voted-by-by-gender" class="section level4">
-<h4>Total Voted by by Gender</h4>
+<h4>Total Voted by Gender</h4>
 <table class="table table-striped" style="width: auto !important; ">
 <thead>
 <tr>


### PR DESCRIPTION
- Thanks for the sharing this information!
- This code change removes what appears to be redundant "by" in 2 of the GA headers.

<img width="1097" alt="Screen Shot 2020-10-24 at 10 20 25 AM" src="https://user-images.githubusercontent.com/507283/97084121-c9f4fc00-15e2-11eb-9ac4-2e8b8a8aa4a1.png">


(Are you generating the `*.html` files from the `*.md` files?)
